### PR TITLE
fix: typo in README (useRouter instead of userRouter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@
     Using useRouter() hook.
 
     ```jsx
-    const router = userRouter();
+    const router = useRouter();
 
     function handleClick() {
       router.push(`/path`);


### PR DESCRIPTION
Hi! I noticed a small typo in the README file.
It uses userRouter() instead of useRouter().

